### PR TITLE
Fix cryptonight crash on Windows

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ sgminer_LDADD    = $(DLOPEN_FLAGS) @LIBCURL_LIBS@ @JANSSON_LIBS@ @PTHREAD_LIBS@ 
 sgminer_CPPFLAGS += -I$(top_builddir)/lib -I$(top_srcdir)/lib @OPENCL_FLAGS@ @LIBCURL_CFLAGS@
 
 if HAVE_WINDOWS
-sgminer_LDFLAGS += -all-static
+sgminer_LDFLAGS += -all-static -Wl,--stack,4194304
 endif
 
 sgminer_CPPFLAGS += $(ADL_CPPFLAGS)


### PR DESCRIPTION
Fixed cryptonight algo crashing on Windows by increasing stack size. Tested on Windows 10 x64 with two GPUs. Further testing needed to see if this change breaks any other algo.

This fixes #3.