### PR TITLE
Fixes for compiler warnings, more support for amdgpu-pro

### DIFF
--- a/algorithm.h
+++ b/algorithm.h
@@ -1,5 +1,6 @@
 #ifndef ALGORITHM_H
 #define ALGORITHM_H
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 
 #ifdef __APPLE_CC__
 #include <OpenCL/opencl.h>

--- a/algorithm/bitblock.c
+++ b/algorithm/bitblock.c
@@ -70,7 +70,7 @@ typedef struct {
     sph_whirlpool_context   whirlpool1;
 } Xhash_context_holder;
 
-static Xhash_context_holder base_contexts;
+extern Xhash_context_holder base_contexts;
 
 
 void init_Bhash_contexts()

--- a/algorithm/cryptonight.c
+++ b/algorithm/cryptonight.c
@@ -142,7 +142,7 @@ static inline uint64_t mul128(uint64_t a, uint64_t b, uint64_t* product_hi)
 #define BYTE(x, y)		(((x) >> ((y) << 3)) & 0xFF)
 #define ROTL32(x, y)	(((x) << (y)) | ((x) >> (32 - (y))))
 
-void CNAESRnd(uint32_t *X, const uint32_t *key)
+void CNAESRnd(uint64_t *X, const uint32_t *key)
 {
 	uint32_t Y[4];
 	
@@ -154,7 +154,7 @@ void CNAESRnd(uint32_t *X, const uint32_t *key)
 	for(int i = 0; i < 4; ++i) X[i] = Y[i] ^ key[i];
 }
 
-void CNAESTransform(uint32_t *X, const uint32_t *Key)
+void CNAESTransform(uint64_t *X, const uint32_t *Key)
 {
 	for(int i = 0; i < 10; ++i)
 	{
@@ -178,13 +178,13 @@ void AESExpandKey256(uint32_t *keybuf)
 	}
 }
 
-void cryptonight(uint8_t *Output, uint8_t *Input)
+void cryptonight(uint32_t *Output, uint32_t *Input)
 {
 	CryptonightCtx CNCtx;
 	uint64_t text[16], a[2], b[2];
 	uint32_t ExpandedKey1[64], ExpandedKey2[64];
 	
-	CNKeccak(CNCtx.State, Input);
+	CNKeccak(CNCtx.State, ((uint64_t *)Input));
 	
 	for(int i = 0; i < 4; ++i) ((uint64_t *)ExpandedKey1)[i] = CNCtx.State[i];
 	for(int i = 0; i < 4; ++i) ((uint64_t *)ExpandedKey2)[i] = CNCtx.State[i + 4];
@@ -214,7 +214,7 @@ void cryptonight(uint8_t *Output, uint8_t *Input)
 		uint64_t c[2];
 		memcpy(c, CNCtx.Scratchpad + ((a[0] & 0x1FFFF0) >> 3), 16);
 		
-		CNAESRnd(c, a);
+		CNAESRnd(c, ((uint32_t *)a));
 		
 		b[0] ^= c[0];
 		b[1] ^= c[1];
@@ -303,7 +303,7 @@ void cryptonight_regenhash(struct work *work)
 		
 	cryptonight(ohash, data);
 	
-	char *tmpdbg = bin2hex(ohash, 32);
+	char *tmpdbg = bin2hex(((const char *)ohash), 32);
 	
 	applog(LOG_DEBUG, "cryptonight_regenhash: %s\n", tmpdbg);
 	

--- a/algorithm/ethash.c
+++ b/algorithm/ethash.c
@@ -29,7 +29,7 @@ uint32_t EthCalcEpochNumber(uint8_t *SeedHash)
   uint8_t TestSeedHash[32] = { 0 };
   
   for(int Epoch = 0; Epoch < 2048; ++Epoch) {
-    SHA3_256(TestSeedHash, TestSeedHash, 32);
+    SHA3_256(((struct ethash_h256 *)TestSeedHash), TestSeedHash, 32);
     if(!memcmp(TestSeedHash, SeedHash, 32)) return(Epoch + 1);
   }
   
@@ -116,7 +116,7 @@ void ethash_regenhash(struct work *work)
   work->Nonce += *((uint32_t *)(work->data + 32));
   applog(LOG_DEBUG, "Regenhash: First qword of input: 0x%016llX.", work->Nonce);
   cg_rlock(&work->pool->data_lock);
-  LightEthash(work->hash, work->mixhash, work->data, work->pool->eth_cache.dag_cache, work->eth_epoch, work->Nonce);
+  LightEthash(work->hash, work->mixhash, work->data, (void*)(work->pool->eth_cache.dag_cache), work->eth_epoch, work->Nonce);
   cg_runlock(&work->pool->data_lock);
   
   char *DbgHash = bin2hex(work->hash, 32);

--- a/algorithm/marucoin.c
+++ b/algorithm/marucoin.c
@@ -66,7 +66,7 @@ typedef struct {
     sph_fugue512_context    fugue1;
 } Xhash_context_holder;
 
-static Xhash_context_holder base_contexts;
+extern Xhash_context_holder base_contexts;
 
 
 void init_Mhash_contexts()

--- a/algorithm/pluck.c
+++ b/algorithm/pluck.c
@@ -215,7 +215,7 @@ static inline uint32_t be32dec(const void *pp)
 }
 #define ROTL(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
 //note, this is 64 bytes
-static inline void xor_salsa8(uint32_t B[16], const uint32_t Bx[16])
+inline void xor_salsa8(uint32_t B[16], const uint32_t Bx[16])
 {
 #define ROTL(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
 	uint32_t x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, x11, x12, x13, x14, x15;

--- a/algorithm/talkcoin.c
+++ b/algorithm/talkcoin.c
@@ -47,7 +47,7 @@ typedef struct
   sph_skein512_context    skein1;
 } Xhash_context_holder;
 
-static Xhash_context_holder base_contexts;
+extern Xhash_context_holder base_contexts;
 
 void init_Nhash_contexts()
 {

--- a/algorithm/x14.c
+++ b/algorithm/x14.c
@@ -68,7 +68,7 @@ typedef struct {
   sph_shabal512_context   shabal1;
 } Xhash_context_holder;
 
-static Xhash_context_holder base_contexts;
+extern Xhash_context_holder base_contexts;
 
 void init_X14hash_contexts()
 {

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,21 @@ if test "x$have_win32" != xtrue; then
 		OPENCL_FLAGS="-I$AMDAPPSDKROOT/include $OPENCL_FLAGS"
 		OPENCL_LIBS="-L$AMDAPPSDKROOT/lib/$ARCH_DIR $OPENCL_LIBS"
 	fi
+
+# Use amdgpu-pro driver and AMDAPPSDK-3.0 if we have them available. This will use the OpenCL
+# library shipped with amdgpu-pro if available, or fall back to the one shipped wit thr
+# AMDAPPSDK if the user doesn't have amdgpu-pro.
+
+	if test -r "/opt/AMDAPPSDK-3.0/include/CL/cl.h"; then
+		OPENCL_FLAGS="-I/opt/AMDAPPSDK-3.0/include $OPENCL_FLAGS";
+		if test -r "/opt/amdgpu-pro/lib/x86_64-linux-gnu/libOpenCL.so"; then
+			OPENCL_LIBS="-L/opt/amdgpu-pro/lib/x86_64-linux-gnu $OPENCL_LIBS";
+		else
+			OPENCL_LIBS="-L/opt/AMDAPPSDK-3.0/lib/x86_64 $OPENCL_LIBS";
+		fi
+		CFLAGS="$CFLAGS $OPENCL_FLAGS";
+		LDFLAGS="$LDFLAGS $OPENCL_LIBS";
+	fi
 fi
 
 have_sgminer_sdk=false

--- a/events.c
+++ b/events.c
@@ -34,6 +34,12 @@
 #include "events.h"
 #include "config_parser.h"
 
+static inline void ignore_result_helper(int __attribute__((unused)) dummy,
+                                        ...) {}
+
+#define IGNORE_RESULT(X) ignore_result_helper(0, (X))
+
+
 // global event list
 event_t *events = NULL, *last_event = NULL;
 
@@ -45,7 +51,7 @@ static void *cmd_thread(void *cmdp)
 	const char *cmd = (const char*)cmdp;
 
 	applog(LOG_DEBUG, "Executing command: %s", cmd);
-	system(cmd);
+	IGNORE_RESULT(system(cmd));
 
 	return NULL;
 }
@@ -265,6 +271,6 @@ void event_notify(const char *event_type)
 
   // quit sgminer if set
   if (event->quit == true)
-    quit(0, ((empty_string(event->quit_msg))?event_type:event->quit_msg));
+    quit(0, "%s", ((empty_string(event->quit_msg))?event_type:event->quit_msg));
 
 }

--- a/findnonce.h
+++ b/findnonce.h
@@ -1,5 +1,6 @@
 #ifndef FINDNONCE_H
 #define FINDNONCE_H
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 
 #include "miner.h"
 #include "config.h"

--- a/miner.h
+++ b/miner.h
@@ -3,10 +3,10 @@
 
 #include "config.h"
 
-#if defined(USE_GIT_VERSION) && defined(GIT_VERSION)
-#undef VERSION
-#define VERSION GIT_VERSION
-#endif
+//#if defined(USE_GIT_VERSION) && defined(GIT_VERSION)
+//#undef VERSION
+//#define VERSION GIT_VERSION
+//#endif
 
 #ifdef BUILD_NUMBER
 #define CGMINER_VERSION VERSION "-" BUILD_NUMBER

--- a/miner.h
+++ b/miner.h
@@ -1,5 +1,7 @@
 #ifndef MINER_H
 #define MINER_H
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_1_APIS
 
 #include "config.h"
 

--- a/ocl.c
+++ b/ocl.c
@@ -6,6 +6,7 @@
  * Software Foundation; either version 3 of the License, or (at your option)
  * any later version.  See COPYING for more details.
  */
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 
 #include "config.h"
 

--- a/ocl.h
+++ b/ocl.h
@@ -1,5 +1,6 @@
 #ifndef OCL_H
 #define OCL_H
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
 
 #include "config.h"
 

--- a/util.c
+++ b/util.c
@@ -1978,8 +1978,8 @@ bool parse_notify_cn(struct pool *pool, json_t *val)
     goto out;
   }
   
-  job_id = json_string_value(jid);
-  hex2bin(&XMRTarget, json_string_value(target), 4);
+  job_id = (char *const)json_string_value(jid);
+  hex2bin((unsigned char *)&XMRTarget, json_string_value(target), 4);
 
   cg_wlock(&pool->data_lock);
   


### PR DESCRIPTION
Fixed some of the more obvious compiler warnings, i.e. incompatible pointers and suchlike. Commented out the define GIT_VERSION, let the declared version win. Compiles *fairly* cleanly on GCC5.4.0 with Ubuntu 16.04.1 if you don't go asking for extra warnings.

Adds a couple of tests to configure.ac to check whether we have the amdgpu-pro driver installed in addition to the AMDAPPSDK. If so, uses libOpenCL.so from amdgpu-pro with headers from the SDK; if we have the SDK but not amdgpu-pro, use the libraries from the SDK. Less to specify at build time, after git and autoreconf I can simply build and install it with:

CFLAGS="-Os -march=native" ./configure && make clean && make -j5 install

NB. These three commits squash a few easy compile warnings, but there's plenty left. Static analysis (with scan-build from clang-4.0 throws up another 80 bugs from dead assignments to logic errors to possible memory leaks, most of which I haven't begun to understand). 