### PR TITLE
Fix debug build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Then:
 To compile a version that can be used accross machines, remove
 `-march=native`.
 
-To compile a debug version, replace `-O2` with `-ggdb`.
+To compile a debug version, replace `-O2` with `-ggdb -fgnu89-inline`.
 
 Depending on your environment, replace `-std=gnu99` with `-std=c99`.
 


### PR DESCRIPTION
-ggdb or -g refuse to compile because of inline function definition issuie described here http://stackoverflow.com/questions/12747198/compiling-error-when-std-gnu99-and-inline-function-is-used