### PR TITLE
Use coin alias to set cryptonight version/variant

### DIFF
--- a/algorithm.c
+++ b/algorithm.c
@@ -1096,9 +1096,9 @@ static cl_int queue_cryptonight_kernel(_clState *clState, dev_blk_ctx *blk, __ma
   unsigned int num = 0;
   cl_int status = 0, tgt32 = *(uint32_t*)(blk->work->target + 28);
 
-  int variant = MIN(1, monero_variant(blk->work)); // limit variant to prevent DOS
-  if (variant != clState->monero_variant) {
-    applog(LOG_NOTICE, "switch to monero variant %d", variant);
+  int variant = cryptonight_variant(blk->work);
+  if (variant != clState->cryptonight_variant) {
+    applog(LOG_NOTICE, "Using cryptonight variant %d", variant);
     char kernel_name[20] = "search1";
     if (variant > 0)
       snprintf(kernel_name + 7, sizeof(kernel_name) - 7, "_var%d", variant);
@@ -1108,7 +1108,7 @@ static cl_int queue_cryptonight_kernel(_clState *clState, dev_blk_ctx *blk, __ma
       applog(LOG_ERR, "Error %d: Creating Kernel \"%s\" from program. (clCreateKernel)", kernel_name, status);
       return status;
     }
-    clState->monero_variant = variant;
+    clState->cryptonight_variant = variant;
   }
 
   memcpy(clState->cldata, blk->work->data, blk->work->XMRBlobLen);
@@ -1364,20 +1364,29 @@ void copy_algorithm_settings(algorithm_t* dest, const char* algo)
   }
 }
 
-static const char *lookup_algorithm_alias(const char *lookup_alias, uint8_t *nfactor)
+static const char *lookup_algorithm_alias(const char *lookup_alias, uint8_t *param)
 {
-#define ALGO_ALIAS_NF(alias, name, nf) \
-  if (strcasecmp(alias, lookup_alias) == 0) { *nfactor = nf; return name; }
+#define ALGO_ALIAS_PARAM(alias, name, p) \
+  if (strcasecmp(alias, lookup_alias) == 0) { *param = p; return name; }
 #define ALGO_ALIAS(alias, name) \
   if (strcasecmp(alias, lookup_alias) == 0) return name;
 
-  ALGO_ALIAS_NF("scrypt", "ckolivas", 10);
-  ALGO_ALIAS_NF("scrypt", "ckolivas", 10);
-  ALGO_ALIAS_NF("adaptive-n-factor", "ckolivas", 11);
-  ALGO_ALIAS_NF("adaptive-nfactor", "ckolivas", 11);
-  ALGO_ALIAS_NF("nscrypt", "ckolivas", 11);
-  ALGO_ALIAS_NF("adaptive-nscrypt", "ckolivas", 11);
-  ALGO_ALIAS_NF("adaptive-n-scrypt", "ckolivas", 11);
+  ALGO_ALIAS_PARAM("scrypt", "ckolivas", 10);
+  ALGO_ALIAS_PARAM("scrypt", "ckolivas", 10);
+  ALGO_ALIAS_PARAM("adaptive-n-factor", "ckolivas", 11);
+  ALGO_ALIAS_PARAM("adaptive-nfactor", "ckolivas", 11);
+  ALGO_ALIAS_PARAM("nscrypt", "ckolivas", 11);
+  ALGO_ALIAS_PARAM("adaptive-nscrypt", "ckolivas", 11);
+  ALGO_ALIAS_PARAM("adaptive-n-scrypt", "ckolivas", 11);
+  ALGO_ALIAS_PARAM("cryptonight", "cryptonight", 1);
+  ALGO_ALIAS_PARAM("xmr", "cryptonight", 1);
+  ALGO_ALIAS_PARAM("xmrv1", "cryptonight", 1);
+  ALGO_ALIAS_PARAM("xmr1", "cryptonight", 1);
+  ALGO_ALIAS_PARAM("monero", "cryptonight", 7);
+  ALGO_ALIAS_PARAM("xmrv7", "cryptonight", 7);
+  ALGO_ALIAS_PARAM("xmr7", "cryptonight", 7);
+  ALGO_ALIAS_PARAM("stellite", "cryptonight", 3);
+  ALGO_ALIAS_PARAM("graft", "cryptonight", 8);
   ALGO_ALIAS("x11mod", "darkcoin-mod");
   ALGO_ALIAS("x11", "darkcoin-mod");
   ALGO_ALIAS("x13mod", "marucoin-mod");
@@ -1406,25 +1415,53 @@ static const char *lookup_algorithm_alias(const char *lookup_alias, uint8_t *nfa
 void set_algorithm(algorithm_t* algo, const char* newname_alias)
 {
   const char *newname;
+  uint8_t nfactor = 10;
+  uint8_t cryptonight_version = 1;
+
+  //load previous cryptonight version value if any
+  uint8_t old_cn_version = ((algo->cryptonight_version) ? algo->cryptonight_version : 0);
 
   //load previous algorithm nfactor in case nfactor was applied before algorithm... or default to 10
   uint8_t old_nfactor = ((algo->nfactor) ? algo->nfactor : 0);
+
   //load previous kernel file name if was applied before algorithm...
   const char *kernelfile = algo->kernelfile;
-  uint8_t nfactor = 10;
 
-  if (!(newname = lookup_algorithm_alias(newname_alias, &nfactor))) {
+  //lookup algorithm alias
+  uint8_t param = 0;
+  if (!(newname = lookup_algorithm_alias(newname_alias, &param))) {
     newname = newname_alias;
   }
 
   copy_algorithm_settings(algo, newname);
 
-  // use old nfactor if it was previously set and is different than the one set by alias
-  if ((old_nfactor > 0) && (old_nfactor != nfactor)) {
+  //use old nfactor if it was previously set and is different than the one set by alias
+  if ((old_nfactor > 0) && (old_nfactor != param)) {
     nfactor = old_nfactor;
+  }
+  else {
+    nfactor = param;
   }
 
   set_algorithm_nfactor(algo, nfactor);
+
+  if (algo->type == ALGO_CRYPTONIGHT) {
+
+    //set default cryptonight version if not returned by alias lookup
+    if (param == 0) {
+      param = cryptonight_version;
+    }
+
+    //use old cryptonight version if it was previously set and is different than the one set by alias
+    if ((old_cn_version > 0) && (old_cn_version != param)) {
+      cryptonight_version = old_cn_version;
+    }
+    else {
+      cryptonight_version = param;
+    }
+
+    algo->cryptonight_version = cryptonight_version;
+  }
 
   //reapply kernelfile if was set
   if (!empty_string(kernelfile)) {
@@ -1434,30 +1471,32 @@ void set_algorithm(algorithm_t* algo, const char* newname_alias)
 
 void set_algorithm_nfactor(algorithm_t* algo, const uint8_t nfactor)
 {
-  algo->nfactor = nfactor;
-  algo->n = (1 << nfactor);
-
-  //adjust algo type accordingly
   switch (algo->type)
   {
-  case ALGO_SCRYPT:
-    //if nfactor isnt 10, switch to NSCRYPT
-    if (algo->nfactor != 10)
-      algo->type = ALGO_NSCRYPT;
-    break;
-    //nscrypt
-  case ALGO_NSCRYPT:
-    //if nfactor is 10, switch to SCRYPT
-    if (algo->nfactor == 10)
-      algo->type = ALGO_SCRYPT;
-    break;
+    //only apply if algo is scrypt or nscrypt
+    case ALGO_NSCRYPT:
+    case ALGO_SCRYPT:
+      algo->nfactor = nfactor;
+      algo->n = (1 << nfactor);
+
+      //if nfactor is 10, switch to SCRYPT
+      if (algo->nfactor == 10) {
+        algo->type = ALGO_SCRYPT;
+      }
+      //otherwise use Nscrypt
+      else {
+        algo->type = ALGO_NSCRYPT;
+      }
+
+      break;
+
     //ignore rest
-  default:
-    break;
+    default:
+      break;
   }
 }
 
 bool cmp_algorithm(const algorithm_t* algo1, const algorithm_t* algo2)
 {
-  return (!safe_cmp(algo1->name, algo2->name) && !safe_cmp(algo1->kernelfile, algo2->kernelfile) && (algo1->nfactor == algo2->nfactor));
+  return (!safe_cmp(algo1->name, algo2->name) && !safe_cmp(algo1->kernelfile, algo2->kernelfile) && (algo1->nfactor == algo2->nfactor) && (algo1->cryptonight_version == algo2->cryptonight_version));
 }

--- a/algorithm.c
+++ b/algorithm.c
@@ -1379,10 +1379,8 @@ static const char *lookup_algorithm_alias(const char *lookup_alias, uint8_t *par
   ALGO_ALIAS_PARAM("adaptive-nscrypt", "ckolivas", 11);
   ALGO_ALIAS_PARAM("adaptive-n-scrypt", "ckolivas", 11);
   ALGO_ALIAS_PARAM("cryptonight", "cryptonight", 1);
-  ALGO_ALIAS_PARAM("xmr", "cryptonight", 1);
-  ALGO_ALIAS_PARAM("xmrv1", "cryptonight", 1);
-  ALGO_ALIAS_PARAM("xmr1", "cryptonight", 1);
   ALGO_ALIAS_PARAM("monero", "cryptonight", 7);
+  ALGO_ALIAS_PARAM("xmr", "cryptonight", 7);
   ALGO_ALIAS_PARAM("xmrv7", "cryptonight", 7);
   ALGO_ALIAS_PARAM("xmr7", "cryptonight", 7);
   ALGO_ALIAS_PARAM("stellite", "cryptonight", 3);

--- a/algorithm.c
+++ b/algorithm.c
@@ -1415,8 +1415,6 @@ static const char *lookup_algorithm_alias(const char *lookup_alias, uint8_t *par
 void set_algorithm(algorithm_t* algo, const char* newname_alias)
 {
   const char *newname;
-  uint8_t nfactor = 10;
-  uint8_t cryptonight_version = 1;
 
   //load previous cryptonight version value if any
   uint8_t old_cn_version = ((algo->cryptonight_version) ? algo->cryptonight_version : 0);
@@ -1435,30 +1433,30 @@ void set_algorithm(algorithm_t* algo, const char* newname_alias)
 
   copy_algorithm_settings(algo, newname);
 
+  //set nfactor
+  uint8_t nfactor;
+
+  //set default nfactor version if not returned by alias lookup
+  if (param == 0) {
+    param = 10;
+  }
+
   //use old nfactor if it was previously set and is different than the one set by alias
-  if ((old_nfactor > 0) && (old_nfactor != param)) {
-    nfactor = old_nfactor;
-  }
-  else {
-    nfactor = param;
-  }
+  nfactor = (((old_nfactor > 0) && (old_nfactor != param)) ? old_nfactor : param );
 
   set_algorithm_nfactor(algo, nfactor);
 
+  //cryptonight version
   if (algo->type == ALGO_CRYPTONIGHT) {
+    uint8_t cryptonight_version;
 
     //set default cryptonight version if not returned by alias lookup
     if (param == 0) {
-      param = cryptonight_version;
+      param = 1;
     }
 
     //use old cryptonight version if it was previously set and is different than the one set by alias
-    if ((old_cn_version > 0) && (old_cn_version != param)) {
-      cryptonight_version = old_cn_version;
-    }
-    else {
-      cryptonight_version = param;
-    }
+    cryptonight_version = (((old_cn_version > 0) && (old_cn_version != param)) ? old_cn_version : param );
 
     algo->cryptonight_version = cryptonight_version;
   }
@@ -1471,14 +1469,14 @@ void set_algorithm(algorithm_t* algo, const char* newname_alias)
 
 void set_algorithm_nfactor(algorithm_t* algo, const uint8_t nfactor)
 {
+  algo->nfactor = nfactor;
+  algo->n = (1 << nfactor);
+
   switch (algo->type)
   {
     //only apply if algo is scrypt or nscrypt
     case ALGO_NSCRYPT:
     case ALGO_SCRYPT:
-      algo->nfactor = nfactor;
-      algo->n = (1 << nfactor);
-
       //if nfactor is 10, switch to SCRYPT
       if (algo->nfactor == 10) {
         algo->type = ALGO_SCRYPT;

--- a/algorithm.h
+++ b/algorithm.h
@@ -62,6 +62,7 @@ typedef struct _algorithm_t {
   const char *kernelfile; /* alternate kernel file */
   uint32_t n;        /* N (CPU/Memory tradeoff parameter) */
   uint8_t  nfactor;  /* Factor of N above (n = 2^nfactor) */
+  uint8_t  cryptonight_version; /* Cryptonight fork version */
   double   diff_multiplier1;
   double   diff_multiplier2;
   double   share_diff_multiplier;

--- a/algorithm/cryptonight.c
+++ b/algorithm/cryptonight.c
@@ -325,7 +325,7 @@ void cryptonight(uint8_t *Output, uint8_t *Input, uint32_t Length, int Variant)
 void cryptonight_regenhash(struct work *work)
 {
 	uint32_t data[20];
-	int variant = monero_variant(work);
+	int variant = cryptonight_variant(work);
 	uint32_t *ohash = (uint32_t *)(work->hash);
 	
 	memcpy(data, work->data, work->XMRBlobLen);
@@ -334,7 +334,7 @@ void cryptonight_regenhash(struct work *work)
 	
 	char *tmpdbg = bin2hex((uint8_t*) ohash, 32);
 	
-	applog(LOG_DEBUG, "cryptonight_regenhash_var%d: %s", variant, tmpdbg);
+	applog(LOG_DEBUG, "cryptonight_regenhash (variant %d): %s", variant, tmpdbg);
 	
 	free(tmpdbg);
 	

--- a/algorithm/cryptonight.h
+++ b/algorithm/cryptonight.h
@@ -7,8 +7,8 @@ typedef struct _CryptonightCtx
   uint64_t Scratchpad[1 << 18];
 } CryptonightCtx;
 
-static inline int monero_variant(struct work *work) {
-  return (work->is_monero && work->data[0] >= 7) ? work->data[0] - 6 : 0;
+static inline int cryptonight_variant(struct work *work) {
+  return (((work->cryptonight_version > 1) && (((uint8_t *)work->data)[0] >= work->cryptonight_version)) ? ((uint8_t *)work->data)[0] - work->cryptonight_version + 1 : 0 );
 }
 
 void cryptonight_regenhash(struct work *work);

--- a/config_parser.c
+++ b/config_parser.c
@@ -1327,9 +1327,6 @@ static json_t *build_pool_json()
     if (pool->no_keepalive)
       json_pool_add(obj, "no-keepalive", json_true(), pool->pool_no);
 
-    if (pool->is_monero)
-      json_pool_add(obj, "monero", json_true(), pool->pool_no);
-
     if (!empty_string(pool->description))
       json_pool_add(obj, "no-description", json_string(pool->description), pool->pool_no);
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -446,7 +446,6 @@ sgminer 4.2.1-116-g2e8b-dirty
   * [gpu-vddc](#gpu-vddc)
   * [intensity](#intensity)
   * [lookup-gap](#lookup-gap)
-  * [monero](#monero)
   * [name](#pool-name)
   * [nfactor](#nfactor)
   * [no-keepalive](#no-keepalive)
@@ -1429,22 +1428,6 @@ See [intensity](#intensity)
 ### [pool-]lookup-gap
 
 See [lookup-gap](#lookup-gap)
-
-[Top](#configuration-and-command-line-options) :: [Config-file and CLI options](#config-file-and-cli-options) :: [Pool Options](#pool-options)
-
-### monero
-
-This flag is required for Monero mining after the hard fork in March 2018. When it is set then the appropriate Cryptonight variant for Monero is chosen automatically.
-
-*Available*: Global, Pool
-
-*Config File Syntax:* `"monero":true`
-
-*Command Line Syntax:* `--monero` `--pool-monero`
-
-*Argument:* None
-
-*Default:* `false`
 
 [Top](#configuration-and-command-line-options) :: [Config-file and CLI options](#config-file-and-cli-options) :: [Pool Options](#pool-options)
 

--- a/miner.h
+++ b/miner.h
@@ -1371,7 +1371,6 @@ struct pool {
   uint8_t XMRBlob[128];
   pthread_mutex_t XMRGlobalNonceLock;
   uint32_t XMRGlobalNonce;
-  bool is_monero;
   
   double diff_accepted;
   double diff_rejected;
@@ -1531,7 +1530,7 @@ struct work {
   
   /* cryptonight stuff */
   uint32_t XMRBlobLen;
-  bool is_monero;
+  uint8_t cryptonight_version;
   
   unsigned char equihash_data[1487];
 

--- a/ocl.h
+++ b/ocl.h
@@ -35,7 +35,7 @@ typedef struct __clState {
   bool goffset;
   cl_uint vwidth;
   int devid;
-  int monero_variant;
+  int cryptonight_variant;
   size_t max_work_size;
   size_t wsize;
   size_t compute_shaders;

--- a/sgminer.c
+++ b/sgminer.c
@@ -1187,16 +1187,6 @@ static char *set_extranonce_subscribe(char *arg)
   return NULL;
 }
 
-static char *set_monero(char *arg)
-{
-  struct pool *pool = get_current_pool();
-
-  applog(LOG_DEBUG, "Select appropriate Cryptonight Monero variant on %d", pool->pool_no);
-  opt_set_bool(&pool->is_monero);
-
-  return NULL;
-}
-
 static char *set_pool_priority(char *arg)
 {
   struct pool *pool = get_current_pool();
@@ -1543,9 +1533,6 @@ struct opt_table opt_config_table[] = {
   OPT_WITHOUT_ARG("--hamsi-short",
       opt_set_bool, &opt_hamsi_short,
       "Set SPH_HAMSI_SHORT for X13 derived algorithms (Can give better hashrate for some GPUs)"),
-  OPT_WITHOUT_ARG("--monero|--pool-monero",
-      set_monero, NULL,
-      "Use Monero Cryptonight variants as appropriate"),
   OPT_WITH_ARG("--keccak-unroll",
       set_int_0_to_9999, opt_show_intval, &opt_keccak_unroll,
       "Set SPH_KECCAK_UNROLL for Xn derived algorithms (Default: 0)"),
@@ -6619,7 +6606,7 @@ static void gen_stratum_work_cn(struct pool *pool, struct work *work)
   work->sdiff = pool->swork.diff;
   work->work_difficulty = work->sdiff;
   work->network_diff = pool->diff1;
-  work->is_monero = pool->is_monero;
+  work->cryptonight_version = pool->algorithm.cryptonight_version;
   cg_runlock(&pool->data_lock);
   
   local_work++;


### PR DESCRIPTION
Use a coin/algorithm alias to set the cryptonight version/variant instead of using new command line option(s). This makes it easier for end users and also simpler to add new forks if needed.